### PR TITLE
Fix literial GitHub in official Capitalization

### DIFF
--- a/public/comment_concept.html
+++ b/public/comment_concept.html
@@ -229,7 +229,7 @@
         <div class="row"> 
           <div class="col"> 
             <ul class="ps-0">
-              <li class="d-inline-block me-3"><a href="#">Github</a></li>
+              <li class="d-inline-block me-3"><a href="#">GitHub</a></li>
               <li class="d-inline-block me-3"><a href="#">Facebook </a></li>
             </ul>
           </div>

--- a/public/disclaimer.html
+++ b/public/disclaimer.html
@@ -44,7 +44,7 @@
         <div class="row"> 
           <div class="col"> 
             <ul class="ps-0">
-              <li class="d-inline-block me-3"><a href="#">Github</a></li>
+              <li class="d-inline-block me-3"><a href="#">GitHub</a></li>
               <li class="d-inline-block me-3"><a href="#">Facebook </a></li>
             </ul>
           </div>

--- a/public/index_concept.html
+++ b/public/index_concept.html
@@ -111,7 +111,7 @@
         <div class="row"> 
           <div class="col"> 
             <ul class="ps-0">
-              <li class="d-inline-block me-3"><a href="#">Github</a></li>
+              <li class="d-inline-block me-3"><a href="#">GitHub</a></li>
               <li class="d-inline-block me-3"><a href="#">Facebook </a></li>
             </ul>
           </div>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -82,7 +82,7 @@
         <div class="row"> 
           <div class="col"> 
             <ul class="ps-0">
-              <li class="d-inline-block me-3"><a href="//github.com/mcuosc/mcu-up" target="_blank">Github</a></li>
+              <li class="d-inline-block me-3"><a href="//github.com/mcuosc/mcu-up" target="_blank">GitHub</a></li>
               <li class="d-inline-block me-3"><a href="//fb.me/upMCU" target="_blank">Facebook</a></li>
               <li class="d-inline-block me-3"><a href="//line.me/ti/g2/ktESOVGy_LoR6m6pDQ2EJw" target="_blank">Line 社群</a></li>
             </ul>

--- a/views/_partial/footer.pug
+++ b/views/_partial/footer.pug
@@ -4,7 +4,7 @@ footer.bg-light.p-4.text-secondary.mt-1
       .col 
         ul.ps-0
           li.d-inline-block.me-3
-            a(href="//github.com/mcuosc/mcu-up" target="_blank") Github
+            a(href="//github.com/mcuosc/mcu-up" target="_blank") GitHub
           li.d-inline-block.me-3
             a(href="//fb.me/upMCU" target="_blank") Facebook
           li.d-inline-block.me-3

--- a/views/home.pug
+++ b/views/home.pug
@@ -48,4 +48,4 @@ block content
             h1.card-title.text-center
               i.fas.fa-file-code
             h4.card-title.text-center 開源
-            p.card-text 網站本體的程式架構以 MIT 授權條款公開於 Github，所有人皆可檢視、修改。
+            p.card-text 網站本體的程式架構以 MIT 授權條款公開於 GitHub，所有人皆可檢視、修改。


### PR DESCRIPTION
Just like the title, GitHub's official name is GitHub rather than Github.
Fix some typos.